### PR TITLE
Change plugin ID to fix build

### DIFF
--- a/src/main/java/rufix/RuFix.java
+++ b/src/main/java/rufix/RuFix.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 
 import java.util.List;
 
-@Plugin(id = "ruFix", name = "RuFix", version = "1.0", description = "ruFix")
+@Plugin(id = "rufix", name = "RuFix", version = "1.0", description = "ruFix")
 public class RuFix {
     private List<String> alias = new ArrayList<>();
 


### PR DESCRIPTION
A build error appeared due to the wrong plugin ID.
According to the error message,
the plugin ID must match pattern '[a-z][a-z0-9-_]{0,63}'.
It should be lower case, start with an alphabetic character
and may only contain alphanumeric characters, underscores or dashes.
See the discussion in yaroslav4167/RuFix#1